### PR TITLE
Wrap EM around tagged examples only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # em-rspec
 
-em-rspec is a very simple patch to RSpec 2 that sets up and tears down an EventMachine reactor loop, and runs each example within the context of the loop. 
-It also will wrap each example in a [Fiber](http://ruby-doc.org/core-1.9/classes/Fiber.html) so you are free to untangle nested callbacks.
+em-rspec is a very simple patch to RSpec 2 that sets up and tears down
+an EventMachine reactor loop, and run examples tagged as
+`eventmachine: true` within the context of the loop.
+It also will wrap examples in a [Fiber](http://ruby-doc.org/core-1.9/classes/Fiber.html) so you are free to untangle nested callbacks.
 
 # Usage
 
@@ -9,9 +11,9 @@ It also will wrap each example in a [Fiber](http://ruby-doc.org/core-1.9/classes
 
 `require 'em-rspec'`
 
-em-rspec extends RSpec in an unobtrusive way that requires no addtional code in your specs to test EM code. e.g.
+em-rspec extends RSpec so that you can decide which specs are to be executed within the context of a reactor loop:
 
-<pre>describe 'em-rspec' do
+<pre>describe 'em-rspec' eventmachine: true do
   it 'executes specs within a reactor loop' do
     EM.reactor_running?.should be_true # This is true
   end

--- a/lib/patch.rb
+++ b/lib/patch.rb
@@ -10,14 +10,20 @@ RSpec::Core::Example.class_eval do
   alias ignorant_run run
 
   def run(example_group_instance, reporter)
-    Fiber.new do
-      EM.run do
-        df = EM::DefaultDeferrable.new
-        df.callback { |x| EM.stop }
-        ignorant_run example_group_instance, reporter
-        df.succeed
-      end
-    end.resume
+    if metadata[:eventmachine]
+      result = false
+      Fiber.new do
+        EM.run do
+          df = EM::DefaultDeferrable.new
+          df.callback { |x| EM.stop }
+          result = ignorant_run(example_group_instance, reporter)
+          df.succeed
+        end
+      end.resume
+      result
+    else
+      ignorant_run(example_group_instance, reporter)
+    end
   end
 
 end

--- a/spec/lib/patch_spec.rb
+++ b/spec/lib/patch_spec.rb
@@ -1,7 +1,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../lib/em-rspec.rb')
 
-describe 'async aware rspec' do
+describe 'async aware rspec', eventmachine: true do
   it 'runs examples with eventmachine reactor' do
     EM.reactor_running?.should be_true
+  end
+end
+
+describe 'async unaware rspec' do
+  it 'runs examples without eventmachine reactor' do
+    EM.reactor_running?.should be_false
   end
 end


### PR DESCRIPTION
Hey,

The current implementation runs every single rspec example within the context of an EM reactor loop. For an EM-unaware, synchronous code this is an unnecessary performance overhead. 

To address it, I added an "eventmachine" tag which decides if given example is to be wrapped in an EM loop, e.g.:

```
describe Foo, eventmachine: true do
...
end
```
