### PR TITLE
fix exit code with Fiber.yield trick

### DIFF
--- a/lib/patch.rb
+++ b/lib/patch.rb
@@ -12,10 +12,11 @@ RSpec::Core::Example.class_eval do
   def run(example_group_instance, reporter)
     Fiber.new do
       EM.run do
-        df = EM::DefaultDeferrable.new
-        df.callback { |x| EM.stop }
-        ignorant_run example_group_instance, reporter
-        df.succeed
+	df = EM::DefaultDeferrable.new
+	result = nil
+	df.callback { |x| EM.stop_event_loop; Fiber.yield result }
+	result = ignorant_run example_group_instance, reporter
+	df.succeed
       end
     end.resume
   end


### PR DESCRIPTION
When run any rspec examples wrapped with em-spec, then exit code is always 1. Example: 
    $ rspec
    Run options: include {:focus=>true}

```
All examples were filtered out; ignoring {:focus=>true}
..

Finished in 0.00114 seconds
2 examples, 0 failures

Randomized with seed 15661

$ echo $?
1
```

This patch allow to respectively shut down the reactor (with calling shutdown hooks if necessary) and return proper return code.
